### PR TITLE
MongodbPersistence: Fix initialization of sequence.

### DIFF
--- a/build/AzDO/sonarcloud.yaml
+++ b/build/AzDO/sonarcloud.yaml
@@ -25,7 +25,7 @@ steps:
   inputs:
     version: 2.2.101
 
-- task: GitVersion@0
+- task: GitVersion@1
   displayName: 'GitVersion '
   inputs:
     BuildNamePrefix: NStore


### PR DESCRIPTION
When sequence in database is used we should init the collection
to avoid multiple processes incur in an error with the very first insert.

fixes  #81