### PR TITLE
Refactor BatchRepository and add AggregateSaveResult factory methods

### DIFF
--- a/src/NStore.Domain.Tests/AggregateSaveResultTests.cs
+++ b/src/NStore.Domain.Tests/AggregateSaveResultTests.cs
@@ -1,0 +1,98 @@
+using NStore.Core.Persistence;
+using Xunit;
+
+namespace NStore.Domain.Tests
+{
+    public class AggregateSaveResultTests
+    {
+        private class StubChunk : IChunk
+        {
+            public long Position { get; set; }
+            public string PartitionId { get; set; }
+            public long Index { get; set; }
+            public object Payload { get; set; }
+            public string OperationId { get; set; }
+        }
+
+        [Fact]
+        public void Unchanged_should_create_successful_result_with_unchanged_failure_kind()
+        {
+            var result = AggregateSaveResult.Unchanged("agg-1");
+
+            Assert.Equal("agg-1", result.AggregateId);
+            Assert.True(result.Succeeded);
+            Assert.Null(result.Chunk);
+            Assert.Equal(AggregateSaveFailureKind.Unchanged, result.FailureKind);
+        }
+
+        [Fact]
+        public void InvariantFailure_should_create_failed_result_with_invariant_failure_kind()
+        {
+            var result = AggregateSaveResult.InvariantFailure("agg-2");
+
+            Assert.Equal("agg-2", result.AggregateId);
+            Assert.False(result.Succeeded);
+            Assert.Null(result.Chunk);
+            Assert.Equal(AggregateSaveFailureKind.InvariantFailure, result.FailureKind);
+        }
+
+        [Fact]
+        public void Committed_should_create_successful_result_with_chunk()
+        {
+            var chunk = new StubChunk { PartitionId = "agg-3", Index = 1 };
+
+            var result = AggregateSaveResult.Committed("agg-3", chunk);
+
+            Assert.Equal("agg-3", result.AggregateId);
+            Assert.True(result.Succeeded);
+            Assert.Same(chunk, result.Chunk);
+            Assert.Null(result.FailureKind);
+        }
+
+        [Fact]
+        public void Concurrency_should_create_failed_result_with_concurrency_failure_kind()
+        {
+            var result = AggregateSaveResult.Concurrency("agg-4");
+
+            Assert.Equal("agg-4", result.AggregateId);
+            Assert.False(result.Succeeded);
+            Assert.Null(result.Chunk);
+            Assert.Equal(AggregateSaveFailureKind.Concurrency, result.FailureKind);
+        }
+
+        [Fact]
+        public void DuplicatedOperation_should_create_successful_result_with_chunk()
+        {
+            var chunk = new StubChunk { PartitionId = "agg-5", Index = 2 };
+
+            var result = AggregateSaveResult.DuplicatedOperation("agg-5", chunk);
+
+            Assert.Equal("agg-5", result.AggregateId);
+            Assert.True(result.Succeeded);
+            Assert.Same(chunk, result.Chunk);
+            Assert.Equal(AggregateSaveFailureKind.DuplicatedOperation, result.FailureKind);
+        }
+
+        [Fact]
+        public void GenericFailure_should_create_failed_result_with_generic_failure_kind()
+        {
+            var result = AggregateSaveResult.GenericFailure("agg-6");
+
+            Assert.Equal("agg-6", result.AggregateId);
+            Assert.False(result.Succeeded);
+            Assert.Null(result.Chunk);
+            Assert.Equal(AggregateSaveFailureKind.GenericFailure, result.FailureKind);
+        }
+
+        [Fact]
+        public void DuplicatedPosition_should_create_failed_result_with_duplicated_position_failure_kind()
+        {
+            var result = AggregateSaveResult.DuplicatedPosition("agg-7");
+
+            Assert.Equal("agg-7", result.AggregateId);
+            Assert.False(result.Succeeded);
+            Assert.Null(result.Chunk);
+            Assert.Equal(AggregateSaveFailureKind.DuplicatedPosition, result.FailureKind);
+        }
+    }
+}

--- a/src/NStore.Domain.Tests/BatchRepositoryTests.cs
+++ b/src/NStore.Domain.Tests/BatchRepositoryTests.cs
@@ -109,7 +109,8 @@ namespace NStore.Domain.Tests
             list.Add(tickets["Ticket_1"]); // duplicate id in input
 
             // Act / Assert
-            await Assert.ThrowsAsync<ArgumentException>(() => BatchRepository.SaveManyAsync(list, "dup_op")).ConfigureAwait(false);
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() => BatchRepository.SaveManyAsync(list, "dup_op")).ConfigureAwait(false);
+            Assert.Contains("Duplicate aggregate id 'Ticket_1' passed to SaveManyAsync", ex.Message);
         }
 
         [Fact]

--- a/src/NStore.Domain/AggregateSaveResult.cs
+++ b/src/NStore.Domain/AggregateSaveResult.cs
@@ -55,5 +55,60 @@ namespace NStore.Domain
             Chunk = null,
             FailureKind = AggregateSaveFailureKind.InvariantFailure
         };
+
+        /// <summary>
+        /// Creates a result indicating the aggregate was successfully committed.
+        /// </summary>
+        public static AggregateSaveResult Committed(string aggregateId, IChunk chunk) => new AggregateSaveResult
+        {
+            AggregateId = aggregateId,
+            Succeeded = true,
+            Chunk = chunk,
+            FailureKind = null
+        };
+
+        /// <summary>
+        /// Creates a result indicating a concurrency conflict (optimistic concurrency violation).
+        /// </summary>
+        public static AggregateSaveResult Concurrency(string aggregateId) => new AggregateSaveResult
+        {
+            AggregateId = aggregateId,
+            Succeeded = false,
+            Chunk = null,
+            FailureKind = AggregateSaveFailureKind.Concurrency
+        };
+
+        /// <summary>
+        /// Creates a result indicating the operation was already executed (idempotency).
+        /// </summary>
+        public static AggregateSaveResult DuplicatedOperation(string aggregateId, IChunk chunk) => new AggregateSaveResult
+        {
+            AggregateId = aggregateId,
+            Succeeded = true,
+            Chunk = chunk,
+            FailureKind = AggregateSaveFailureKind.DuplicatedOperation
+        };
+
+        /// <summary>
+        /// Creates a result indicating a generic failure from the persistence layer.
+        /// </summary>
+        public static AggregateSaveResult GenericFailure(string aggregateId) => new AggregateSaveResult
+        {
+            AggregateId = aggregateId,
+            Succeeded = false,
+            Chunk = null,
+            FailureKind = AggregateSaveFailureKind.GenericFailure
+        };
+
+        /// <summary>
+        /// Creates a result indicating a position conflict after retry limit exceeded.
+        /// </summary>
+        public static AggregateSaveResult DuplicatedPosition(string aggregateId) => new AggregateSaveResult
+        {
+            AggregateId = aggregateId,
+            Succeeded = false,
+            Chunk = null,
+            FailureKind = AggregateSaveFailureKind.DuplicatedPosition
+        };
     }
 }

--- a/src/NStore.Domain/AggregateSaveResult.cs
+++ b/src/NStore.Domain/AggregateSaveResult.cs
@@ -33,5 +33,27 @@ namespace NStore.Domain
         /// save succeeded and no special condition applies.
         /// </summary>
         public AggregateSaveFailureKind? FailureKind { get; internal set; }
+
+        /// <summary>
+        /// Creates a result indicating the aggregate had no changes to persist.
+        /// </summary>
+        public static AggregateSaveResult Unchanged(string aggregateId) => new AggregateSaveResult
+        {
+            AggregateId = aggregateId,
+            Succeeded = true,
+            Chunk = null,
+            FailureKind = AggregateSaveFailureKind.Unchanged
+        };
+
+        /// <summary>
+        /// Creates a result indicating the aggregate failed invariant validation.
+        /// </summary>
+        public static AggregateSaveResult InvariantFailure(string aggregateId) => new AggregateSaveResult
+        {
+            AggregateId = aggregateId,
+            Succeeded = false,
+            Chunk = null,
+            FailureKind = AggregateSaveFailureKind.InvariantFailure
+        };
     }
 }

--- a/src/NStore.Domain/BatchRepository.cs
+++ b/src/NStore.Domain/BatchRepository.cs
@@ -283,22 +283,12 @@ namespace NStore.Domain
                 {
                     var aggregate = aggregateByPartitionId[job.PartitionId];
                     var persister = (IEventSourcedAggregate)aggregate;
-                    var saveResult = new AggregateSaveResult
-                    {
-                        AggregateId = aggregate.Id
-                    };
 
                     switch (job.Result)
                     {
                         case WriteJob.WriteResult.Committed:
-                            // Success - notify aggregate (which updates its Version internally)
                             persister.Persisted(persister.GetChangeSet());
-
-                            saveResult.Succeeded = true;
-                            saveResult.Chunk = job.Chunk;
-                            saveResult.FailureKind = null;
-
-                            // Collect snapshot if supported
+                            listOfAggregateSaveResult.Add(AggregateSaveResult.Committed(aggregate.Id, job.Chunk));
                             if (_snapshotBatchStore != null && aggregate is ISnapshottable snapshottable)
                             {
                                 snapshotsToSave[aggregate.Id] = snapshottable.GetSnapshot();
@@ -306,35 +296,21 @@ namespace NStore.Domain
                             break;
 
                         case WriteJob.WriteResult.DuplicatedIndex:
-                            // Optimistic concurrency violation - another process modified this aggregate
-                            saveResult.Succeeded = false;
-                            saveResult.Chunk = null;
-                            saveResult.FailureKind = AggregateSaveFailureKind.Concurrency;
+                            listOfAggregateSaveResult.Add(AggregateSaveResult.Concurrency(aggregate.Id));
                             break;
 
                         case WriteJob.WriteResult.DuplicatedOperation:
-                            // Operation was already executed (idempotency check passed) - treat as success
-                            saveResult.Succeeded = true;
-                            saveResult.Chunk = job.Chunk; // May be null for duplicated operations
-                            saveResult.FailureKind = AggregateSaveFailureKind.DuplicatedOperation;
+                            listOfAggregateSaveResult.Add(AggregateSaveResult.DuplicatedOperation(aggregate.Id, job.Chunk));
                             break;
 
                         case WriteJob.WriteResult.Failed:
-                            // Generic failure from persistence layer
-                            saveResult.Succeeded = false;
-                            saveResult.Chunk = null;
-                            saveResult.FailureKind = AggregateSaveFailureKind.GenericFailure;
+                            listOfAggregateSaveResult.Add(AggregateSaveResult.GenericFailure(aggregate.Id));
                             break;
 
                         case WriteJob.WriteResult.DuplicatedPosition:
-                            // Position conflict after retry limit exceeded
-                            saveResult.Succeeded = false;
-                            saveResult.Chunk = null;
-                            saveResult.FailureKind = AggregateSaveFailureKind.DuplicatedPosition;
+                            listOfAggregateSaveResult.Add(AggregateSaveResult.DuplicatedPosition(aggregate.Id));
                             break;
                     }
-
-                    listOfAggregateSaveResult.Add(saveResult);
                 }
 
                 // Step 4: Save snapshots in batch (best-effort)

--- a/src/NStore.Domain/BatchRepository.cs
+++ b/src/NStore.Domain/BatchRepository.cs
@@ -282,34 +282,15 @@ namespace NStore.Domain
                 foreach (var job in writeJobs)
                 {
                     var aggregate = aggregateByPartitionId[job.PartitionId];
-                    var persister = (IEventSourcedAggregate)aggregate;
+                    listOfAggregateSaveResult.Add(MapJobResult(job, aggregate.Id));
 
-                    switch (job.Result)
+                    if (job.Result == WriteJob.WriteResult.Committed)
                     {
-                        case WriteJob.WriteResult.Committed:
-                            persister.Persisted(persister.GetChangeSet());
-                            listOfAggregateSaveResult.Add(AggregateSaveResult.Committed(aggregate.Id, job.Chunk));
-                            if (_snapshotBatchStore != null && aggregate is ISnapshottable snapshottable)
-                            {
-                                snapshotsToSave[aggregate.Id] = snapshottable.GetSnapshot();
-                            }
-                            break;
-
-                        case WriteJob.WriteResult.DuplicatedIndex:
-                            listOfAggregateSaveResult.Add(AggregateSaveResult.Concurrency(aggregate.Id));
-                            break;
-
-                        case WriteJob.WriteResult.DuplicatedOperation:
-                            listOfAggregateSaveResult.Add(AggregateSaveResult.DuplicatedOperation(aggregate.Id, job.Chunk));
-                            break;
-
-                        case WriteJob.WriteResult.Failed:
-                            listOfAggregateSaveResult.Add(AggregateSaveResult.GenericFailure(aggregate.Id));
-                            break;
-
-                        case WriteJob.WriteResult.DuplicatedPosition:
-                            listOfAggregateSaveResult.Add(AggregateSaveResult.DuplicatedPosition(aggregate.Id));
-                            break;
+                        ((IEventSourcedAggregate)aggregate).Persisted(((IEventSourcedAggregate)aggregate).GetChangeSet());
+                        if (_snapshotBatchStore != null && aggregate is ISnapshottable snapshottable)
+                        {
+                            snapshotsToSave[aggregate.Id] = snapshottable.GetSnapshot();
+                        }
                     }
                 }
 
@@ -330,6 +311,21 @@ namespace NStore.Domain
         public void Clear()
         {
             _trackingAggregates.Clear();
+        }
+
+        private static AggregateSaveResult MapJobResult(WriteJob job, string aggregateId)
+        {
+            switch (job.Result)
+            {
+                case WriteJob.WriteResult.Committed: return AggregateSaveResult.Committed(aggregateId, job.Chunk);
+                case WriteJob.WriteResult.DuplicatedIndex: return AggregateSaveResult.Concurrency(aggregateId);
+                case WriteJob.WriteResult.DuplicatedOperation: return AggregateSaveResult.DuplicatedOperation(aggregateId, job.Chunk);
+                case WriteJob.WriteResult.DuplicatedPosition: return AggregateSaveResult.DuplicatedPosition(aggregateId);
+                
+                case WriteJob.WriteResult.None:
+                case WriteJob.WriteResult.Failed:
+                default: return AggregateSaveResult.GenericFailure(aggregateId);
+            }
         }
     }
 }

--- a/src/NStore.Domain/BatchRepository.cs
+++ b/src/NStore.Domain/BatchRepository.cs
@@ -115,21 +115,16 @@ namespace NStore.Domain
                     subscription.LastError);
             }
 
-            // now we need to understand if we have stale snapshot and mark all the aggregates as initialized
+            // Mark aggregates as loaded and check for stale snapshots
             foreach (var kvp in aggregates)
             {
-                var aggregate = kvp.Value;
-                aggregate.Loaded();
+                kvp.Value.Loaded();
+
                 var snapshotVersion = snapshotVersions[kvp.Key];
-                if (!countOfEventsRead.TryGetValue(kvp.Key, out var eventsRead))
-                {
-                    eventsRead = 0;
-                }
+                countOfEventsRead.TryGetValue(kvp.Key, out var eventsRead);
+
                 if (snapshotVersion > 0 && eventsRead == 0)
-                {
-                    // immediately throw
-                    throw new StaleSnapshotException(aggregate.Id, snapshotVersion);
-                }
+                    throw new StaleSnapshotException(kvp.Value.Id, snapshotVersion);
             }
 
             return aggregates;
@@ -212,64 +207,20 @@ namespace NStore.Domain
             // Step 1: Validate all aggregates and prepare write jobs
             var writeJobs = new List<WriteJob>();
             var aggregateByPartitionId = new Dictionary<string, IAggregate>();
-
-            // first step is preparing the write jobs for all aggregates to persist in a batch.
             var seen = new HashSet<string>();
             var listOfAggregateSaveResult = new List<AggregateSaveResult>();
+
             foreach (var aggregate in aggregates)
             {
-                // Check for duplicate aggregate ids in the input - this is not allowed
-                if (!seen.Add(aggregate.Id))
-                {
-                    throw new ArgumentException($"Duplicate aggregate id '{aggregate.Id}' passed to SaveManyAsync");
-                }
+                var result = PrepareAggregate(aggregate, operationId, headers, seen);
 
-                // Validate aggregate is tracked by this repository (unless it's a new aggregate)
-                if (!_trackingAggregates.ContainsKey(aggregate.Id))
+                if (result.EarlyResult != null)
                 {
-                    if (aggregate.IsNew)
-                    {
-                        _trackingAggregates[aggregate.Id] = aggregate;
-                    }
-                    else
-                    {
-                        throw new RepositoryMismatchException($"Aggregate {aggregate.Id} was not loaded by this batch repository");
-                    }
-                }
-
-                var persister = (IEventSourcedAggregate)aggregate;
-                var changeSet = persister.GetChangeSet();
-
-                // Skip empty changesets unless configured to persist them; report as Unchanged instead of omitting
-                if (changeSet.IsEmpty() && !PersistEmptyChangeset)
-                {
-                    listOfAggregateSaveResult.Add(AggregateSaveResult.Unchanged(aggregate.Id));
+                    listOfAggregateSaveResult.Add(result.EarlyResult);
                     continue;
                 }
 
-                // Check invariants if supported - collect failures to report per-aggregate instead of throwing
-                if (aggregate is IInvariantsChecker checker)
-                {
-                    var check = checker.CheckInvariants();
-                    if (check.IsInvalid)
-                    {
-                        listOfAggregateSaveResult.Add(AggregateSaveResult.InvariantFailure(aggregate.Id));
-                        continue;
-                    }
-                }
-
-                // Apply headers if provided
-                headers?.Invoke(changeSet);
-
-                // Create write job - use changeSet.AggregateVersion which is already Version + 1
-                var job = new WriteJob(
-                    aggregate.Id,
-                    changeSet.AggregateVersion,
-                    changeSet,
-                    operationId ?? Guid.NewGuid().ToString()
-                );
-
-                writeJobs.Add(job);
+                writeJobs.Add(result.Job);
                 aggregateByPartitionId[aggregate.Id] = aggregate;
             }
 
@@ -311,6 +262,49 @@ namespace NStore.Domain
         public void Clear()
         {
             _trackingAggregates.Clear();
+        }
+
+        private (AggregateSaveResult EarlyResult, WriteJob Job) PrepareAggregate(
+            IAggregate aggregate,
+            string operationId,
+            Action<IHeadersAccessor> headers,
+            HashSet<string> seen)
+        {
+            // Check for duplicate aggregate ids in the input
+            if (!seen.Add(aggregate.Id))
+                throw new ArgumentException($"Duplicate aggregate id '{aggregate.Id}' passed to SaveManyAsync");
+
+            // Validate aggregate is tracked by this repository (unless it's a new aggregate)
+            if (!_trackingAggregates.ContainsKey(aggregate.Id))
+            {
+                if (aggregate.IsNew)
+                    _trackingAggregates[aggregate.Id] = aggregate;
+                else
+                    throw new RepositoryMismatchException($"Aggregate {aggregate.Id} was not loaded by this batch repository");
+            }
+
+            var persister = (IEventSourcedAggregate)aggregate;
+            var changeSet = persister.GetChangeSet();
+
+            // Skip empty changesets unless configured to persist them
+            if (changeSet.IsEmpty() && !PersistEmptyChangeset)
+                return (AggregateSaveResult.Unchanged(aggregate.Id), null);
+
+            // Check invariants if supported
+            if (aggregate is IInvariantsChecker checker && checker.CheckInvariants().IsInvalid)
+                return (AggregateSaveResult.InvariantFailure(aggregate.Id), null);
+
+            // Apply headers if provided
+            headers?.Invoke(changeSet);
+
+            var job = new WriteJob(
+                aggregate.Id,
+                changeSet.AggregateVersion,
+                changeSet,
+                operationId ?? Guid.NewGuid().ToString()
+            );
+
+            return (null, job);
         }
 
         private static AggregateSaveResult MapJobResult(WriteJob job, string aggregateId)

--- a/src/NStore.Domain/BatchRepository.cs
+++ b/src/NStore.Domain/BatchRepository.cs
@@ -213,17 +213,17 @@ namespace NStore.Domain
             var writeJobs = new List<WriteJob>();
             var aggregateByPartitionId = new Dictionary<string, IAggregate>();
 
-            // Check for duplicate aggregate ids in the input - this is not allowed
-            var duplicate = aggregates.GroupBy(a => a.Id).FirstOrDefault(g => g.Count() > 1);
-            if (duplicate != null)
-            {
-                throw new ArgumentException($"Duplicate aggregate id '{duplicate.Key}' passed to SaveManyAsync");
-            }
-
             // first step is preparing the write jobs for all aggregates to persist in a batch.
+            var seen = new HashSet<string>();
             var listOfAggregateSaveResult = new List<AggregateSaveResult>();
             foreach (var aggregate in aggregates)
             {
+                // Check for duplicate aggregate ids in the input - this is not allowed
+                if (!seen.Add(aggregate.Id))
+                {
+                    throw new ArgumentException($"Duplicate aggregate id '{aggregate.Id}' passed to SaveManyAsync");
+                }
+
                 // Validate aggregate is tracked by this repository (unless it's a new aggregate)
                 if (!_trackingAggregates.ContainsKey(aggregate.Id))
                 {
@@ -243,14 +243,7 @@ namespace NStore.Domain
                 // Skip empty changesets unless configured to persist them; report as Unchanged instead of omitting
                 if (changeSet.IsEmpty() && !PersistEmptyChangeset)
                 {
-                    //we do not need to save the aggregate, just report it as unchanged
-                    listOfAggregateSaveResult.Add(new AggregateSaveResult
-                    {
-                        AggregateId = aggregate.Id,
-                        Succeeded = true,
-                        Chunk = null,
-                        FailureKind = AggregateSaveFailureKind.Unchanged
-                    });
+                    listOfAggregateSaveResult.Add(AggregateSaveResult.Unchanged(aggregate.Id));
                     continue;
                 }
 
@@ -260,13 +253,7 @@ namespace NStore.Domain
                     var check = checker.CheckInvariants();
                     if (check.IsInvalid)
                     {
-                        listOfAggregateSaveResult.Add(new AggregateSaveResult
-                        {
-                            AggregateId = aggregate.Id,
-                            Succeeded = false,
-                            Chunk = null,
-                            FailureKind = AggregateSaveFailureKind.InvariantFailure
-                        });
+                        listOfAggregateSaveResult.Add(AggregateSaveResult.InvariantFailure(aggregate.Id));
                         continue;
                     }
                 }
@@ -351,7 +338,7 @@ namespace NStore.Domain
                 }
 
                 // Step 4: Save snapshots in batch (best-effort)
-                if (snapshotsToSave.Count > 0)
+                if (_snapshotBatchStore != null && snapshotsToSave.Count > 0)
                 {
                     await _snapshotBatchStore.AddManyAsync(snapshotsToSave, cancellationToken).ConfigureAwait(false);
                 }


### PR DESCRIPTION
## Summary
- Add factory methods to `AggregateSaveResult` for cleaner instantiation (`Unchanged`, `InvariantFailure`, `Committed`, `Concurrency`, `DuplicatedOperation`, `GenericFailure`, `DuplicatedPosition`)
- Extract `PrepareAggregate` helper to reduce complexity in `SaveManyAsync`
- Extract `MapJobResult` helper for cleaner result mapping
- Replace LINQ `GroupBy` duplicate check with `HashSet<string>` for O(n) performance

## Test plan
- [x] Added unit tests for all 7 factory methods in `AggregateSaveResultTests.cs`
- [x] Added assertion to verify duplicate aggregate exception message
- [ ] Run existing test suite to verify no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)