### PR TITLE
Prevent poller checkpoint advancement on failed delivery

### DIFF
--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -35,7 +35,9 @@ services:
       start_period: 20s
 
   tests:
-    image: mcr.microsoft.com/dotnet/sdk:10.0
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.tests   # SDK 10 + .NET 6 runtime (for the net6.0 target)
     depends_on:
       mongo:
         condition: service_healthy
@@ -46,7 +48,8 @@ services:
       # Connection strings consumed by the test fixtures (NSTORE_MONGODB / NSTORE_MSSQL).
       NSTORE_MONGODB: "mongodb://mongo:27017/nstoredev"
       NSTORE_MSSQL: "Server=mssql,1433;User Id=sa;Password=${MSSQL_SA_PASSWORD:-NStore_Test_Passw0rd!};Encrypt=False;TrustServerCertificate=True;"
-      NSTORE_TEST_TFM: "${NSTORE_TEST_TFM:-net10.0}"
+      # Space-separated list of target frameworks to run (both by default).
+      NSTORE_TEST_TFM: "${NSTORE_TEST_TFM:-net6.0 net10.0}"
       # Extra arguments forwarded to `dotnet test` (e.g. --filter ...).
       NSTORE_TEST_ARGS: "${NSTORE_TEST_ARGS:-}"
       # Quiet the poller/log noise during the run (matches CI).

--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -1,0 +1,71 @@
+# Runs the NStore persistence test suites against real providers (MongoDB, SQL
+# Server, SQLite) inside containers, so every developer tests against the same
+# provider versions with only Docker installed.
+#
+# Usage:  ./test-with-docker.sh          (recommended wrapper)
+#     or: docker compose -f docker-compose.tests.yml up --build --exit-code-from tests
+#
+# Overridable via environment / .env:
+#   MSSQL_SA_PASSWORD  SQL Server 'sa' password (must meet SQL complexity rules)
+#   NSTORE_TEST_TFM    target framework to run (default net10.0)
+
+services:
+  mongo:
+    image: mongo:7
+    tmpfs:
+      - /data/db            # keep test data in RAM; nothing to clean up on disk
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD:-NStore_Test_Passw0rd!}"
+      MSSQL_PID: "Developer"
+    healthcheck:
+      # 2022-latest ships sqlcmd under mssql-tools18; -C trusts the self-signed cert.
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -Q 'SELECT 1' -b"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+  tests:
+    image: mcr.microsoft.com/dotnet/sdk:10.0
+    depends_on:
+      mongo:
+        condition: service_healthy
+      mssql:
+        condition: service_healthy
+    working_dir: /workspace
+    environment:
+      # Connection strings consumed by the test fixtures (NSTORE_MONGODB / NSTORE_MSSQL).
+      NSTORE_MONGODB: "mongodb://mongo:27017/nstoredev"
+      NSTORE_MSSQL: "Server=mssql,1433;User Id=sa;Password=${MSSQL_SA_PASSWORD:-NStore_Test_Passw0rd!};Encrypt=False;TrustServerCertificate=True;"
+      NSTORE_TEST_TFM: "${NSTORE_TEST_TFM:-net10.0}"
+      # Extra arguments forwarded to `dotnet test` (e.g. --filter ...).
+      NSTORE_TEST_ARGS: "${NSTORE_TEST_ARGS:-}"
+      # Quiet the poller/log noise during the run (matches CI).
+      NSTORE_LOG_POLLER: "none"
+      NSTORE_LOG_LEVEL: "none"
+      # Skip the first-run .NET welcome/telemetry chatter.
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "1"
+    volumes:
+      - .:/workspace
+      - nuget-cache:/root/.nuget/packages   # cache restores between runs
+      # SQLite tests create their .db file in the test assembly's output directory.
+      # On a host bind-mount (macOS/Windows) SQLite's POSIX file locking is unreliable
+      # and yields spurious "database is locked" errors, so keep that output on a
+      # container-local (native, exec-capable) volume instead. A plain tmpfs would be
+      # mounted noexec and break loading of the native e_sqlite3.so, so use a volume.
+      - sqlite-bin:/workspace/src/NStore.Persistence.Sqlite.Tests/bin
+    entrypoint: ["bash", "/workspace/docker/run-tests.sh"]
+
+volumes:
+  nuget-cache:
+  sqlite-bin:

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -1,0 +1,16 @@
+# Test runner image: .NET 10 SDK (to build everything) plus the .NET 6 runtime
+# (so the net6.0 target of the test projects can actually execute). The SDK image
+# only ships the .NET 10 runtime, so net6.0 test hosts would fail to start without
+# this.
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+# Install the .NET 6 shared runtime alongside the SDK. dotnet-install places it under
+# the same DOTNET_ROOT (/usr/share/dotnet) so `dotnet test -f net6.0` finds it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel 6.0 --runtime dotnet --install-dir /usr/share/dotnet \
+    && rm /tmp/dotnet-install.sh \
+    && dotnet --list-runtimes

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,6 +20,24 @@ Forward extra arguments straight to `dotnet test`:
 ./test-with-docker.sh --filter "FullyQualifiedName~Polling"
 ```
 
+## Where to see failures
+
+Results are written to `./TestResults/` (on the host, so they survive container
+teardown; the directory is git-ignored):
+
+- `run.log` — the full runner console output (clean; no DB server noise).
+- `<Suite>.trx` — one structured result file per suite, e.g.
+  `NStore.Persistence.Mongo.Tests.trx`, openable in Visual Studio / Rider or any
+  `.trx` viewer.
+
+Quick triage:
+
+```bash
+grep -E "Failed|error|FAILED suites" TestResults/run.log
+```
+
+The script also prints the results location and failing-suite hints when it finishes.
+
 ## What runs
 
 | Suite                            | Provider   | Backing container                         |

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,9 +26,9 @@ Results are written to `./TestResults/` (on the host, so they survive container
 teardown; the directory is git-ignored):
 
 - `run.log` — the full runner console output (clean; no DB server noise).
-- `<Suite>.trx` — one structured result file per suite, e.g.
-  `NStore.Persistence.Mongo.Tests.trx`, openable in Visual Studio / Rider or any
-  `.trx` viewer.
+- `<Suite>.<tfm>.trx` — one structured result file per suite **and framework**, e.g.
+  `NStore.Persistence.Mongo.Tests.net10.0.trx`, openable in Visual Studio / Rider or
+  any `.trx` viewer.
 
 Quick triage:
 
@@ -56,19 +56,23 @@ Set via environment variables (or a `.env` file next to the compose file):
 | Variable            | Default                 | Purpose                                   |
 | ------------------- | ----------------------- | ----------------------------------------- |
 | `MSSQL_SA_PASSWORD` | `NStore_Test_Passw0rd!` | SQL Server `sa` password                  |
-| `NSTORE_TEST_TFM`   | `net10.0`               | Target framework to run                   |
+| `NSTORE_TEST_TFM`   | `net6.0 net10.0`        | Space-separated frameworks to run         |
 
-`net10.0` is the default because the `dotnet/sdk:10.0` image ships only the .NET 10
-runtime; the projects also target `net6.0`, but running that here would need the .NET 6
-runtime added to the image.
+Both target frameworks run by default. The runner image (`docker/Dockerfile.tests`)
+is the .NET 10 SDK plus the .NET 6 shared runtime, so the `net6.0` test hosts can
+execute. To run a single framework:
+
+```bash
+NSTORE_TEST_TFM=net10.0 ./test-with-docker.sh
+```
 
 ## Notes / troubleshooting
 
 - **Requirements:** Docker with the Compose plugin. SQL Server needs ~2 GB of RAM
   available to Docker.
-- **First run is slow** — it pulls the MongoDB, SQL Server, and .NET SDK images and
-  restores NuGet packages. The NuGet cache and SQLite build output are kept in named
-  volumes so later runs are faster.
+- **First run is slow** — it pulls the MongoDB and SQL Server images, builds the
+  runner image (SDK 10 + .NET 6 runtime), and restores NuGet packages. The NuGet cache
+  and SQLite build output are kept in named volumes so later runs are faster.
 - **SQLite on a bind mount:** the SQLite `.db` file is written to a container-local
   Docker volume rather than the bind-mounted source tree, because SQLite's POSIX file
   locking is unreliable over the host bind-mount (macOS/Windows) and would otherwise

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,59 @@
+# Provider tests in Docker
+
+Run the persistence test suites against **real** providers (MongoDB, SQL Server,
+SQLite) in containers, so every developer tests the same versions with only Docker
+installed — no local .NET SDK, MongoDB, or SQL Server required.
+
+## Run
+
+```bash
+./test-with-docker.sh
+```
+
+This builds/starts the containers, waits for MongoDB and SQL Server to be healthy,
+runs the three provider suites, prints a combined summary, and exits non-zero if any
+suite fails. Containers are stopped automatically on exit.
+
+Forward extra arguments straight to `dotnet test`:
+
+```bash
+./test-with-docker.sh --filter "FullyQualifiedName~Polling"
+```
+
+## What runs
+
+| Suite                            | Provider   | Backing container                         |
+| -------------------------------- | ---------- | ----------------------------------------- |
+| `NStore.Persistence.Sqlite.Tests`| SQLite     | none (runs in the SDK runner)             |
+| `NStore.Persistence.Mongo.Tests` | MongoDB    | `mongo:7`                                 |
+| `NStore.Persistence.MsSql.Tests` | SQL Server | `mcr.microsoft.com/mssql/server:2022-latest` |
+
+The in-memory provider is intentionally excluded — it needs no external service and
+is exercised by `NStore.Core.Tests`.
+
+## Configuration
+
+Set via environment variables (or a `.env` file next to the compose file):
+
+| Variable            | Default                 | Purpose                                   |
+| ------------------- | ----------------------- | ----------------------------------------- |
+| `MSSQL_SA_PASSWORD` | `NStore_Test_Passw0rd!` | SQL Server `sa` password                  |
+| `NSTORE_TEST_TFM`   | `net10.0`               | Target framework to run                   |
+
+`net10.0` is the default because the `dotnet/sdk:10.0` image ships only the .NET 10
+runtime; the projects also target `net6.0`, but running that here would need the .NET 6
+runtime added to the image.
+
+## Notes / troubleshooting
+
+- **Requirements:** Docker with the Compose plugin. SQL Server needs ~2 GB of RAM
+  available to Docker.
+- **First run is slow** — it pulls the MongoDB, SQL Server, and .NET SDK images and
+  restores NuGet packages. The NuGet cache and SQLite build output are kept in named
+  volumes so later runs are faster.
+- **SQLite on a bind mount:** the SQLite `.db` file is written to a container-local
+  Docker volume rather than the bind-mounted source tree, because SQLite's POSIX file
+  locking is unreliable over the host bind-mount (macOS/Windows) and would otherwise
+  produce spurious `database is locked` errors.
+- **Reset everything** (including cached volumes):
+  `docker compose -f docker-compose.tests.yml down -v`

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -4,7 +4,8 @@
 # Not meant to be run directly on the host - use ./test-with-docker.sh instead.
 set -uo pipefail
 
-TFM="${NSTORE_TEST_TFM:-net10.0}"
+# One or more target frameworks to run (space-separated), e.g. "net6.0 net10.0".
+read -r -a FRAMEWORKS <<< "${NSTORE_TEST_TFM:-net6.0 net10.0}"
 
 # Structured results (.trx) and the console log are written here. This lives on the
 # bind-mounted workspace, so the files survive container teardown and are readable on
@@ -26,7 +27,7 @@ PROJECTS=(
 run_all() {
   echo "=================================================================="
   echo " NStore provider tests"
-  echo "   framework : ${TFM}"
+  echo "   frameworks: ${FRAMEWORKS[*]}"
   echo "   mongodb   : ${NSTORE_MONGODB:-<unset>}"
   echo "   mssql     : ${NSTORE_MSSQL:+<set>}"
   echo "   results   : ${RESULTS_DIR}"
@@ -36,20 +37,22 @@ run_all() {
   for project in "${PROJECTS[@]}"; do
     local name
     name="$(basename "$(dirname "$project")")"
-    echo ""
-    echo ">>> Testing ${name} (${TFM})"
-    if dotnet test "$project" \
-        --framework "$TFM" \
-        --nologo \
-        --logger "console;verbosity=normal" \
-        --logger "trx;LogFileName=${name}.trx" \
-        --results-directory "$RESULTS_DIR" \
-        "${EXTRA_ARGS[@]}"; then
-      echo "<<< ${name}: PASSED"
-    else
-      echo "<<< ${name}: FAILED"
-      failed+=("$name")
-    fi
+    for tfm in "${FRAMEWORKS[@]}"; do
+      echo ""
+      echo ">>> Testing ${name} (${tfm})"
+      if dotnet test "$project" \
+          --framework "$tfm" \
+          --nologo \
+          --logger "console;verbosity=normal" \
+          --logger "trx;LogFileName=${name}.${tfm}.trx" \
+          --results-directory "$RESULTS_DIR" \
+          "${EXTRA_ARGS[@]}"; then
+        echo "<<< ${name} (${tfm}): PASSED"
+      else
+        echo "<<< ${name} (${tfm}): FAILED"
+        failed+=("${name} (${tfm})")
+      fi
+    done
   done
 
   echo ""
@@ -61,6 +64,7 @@ run_all() {
     return 0
   fi
 
+  local IFS=,
   echo " FAILED suites: ${failed[*]}"
   echo " See ${RESULTS_DIR}/run.log and the per-suite .trx files for details."
   echo "=================================================================="

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -6,6 +6,15 @@ set -uo pipefail
 
 TFM="${NSTORE_TEST_TFM:-net10.0}"
 
+# Structured results (.trx) and the console log are written here. This lives on the
+# bind-mounted workspace, so the files survive container teardown and are readable on
+# the host (matches the repo's ignored [Tt]est[Rr]esult*/ convention).
+RESULTS_DIR="${NSTORE_TEST_RESULTS_DIR:-/workspace/TestResults}"
+
+# Extra args forwarded to `dotnet test` (e.g. --filter "FullyQualifiedName~Polling"),
+# passed in via the NSTORE_TEST_ARGS environment variable. Word-split on spaces.
+read -r -a EXTRA_ARGS <<< "${NSTORE_TEST_ARGS:-}"
+
 # Provider test projects to run (in-memory is covered by NStore.Core.Tests and is
 # intentionally excluded here - these are the projects that need real providers).
 PROJECTS=(
@@ -14,42 +23,54 @@ PROJECTS=(
   "src/NStore.Persistence.MsSql.Tests/NStore.Persistence.MsSql.Tests.csproj"
 )
 
-echo "=================================================================="
-echo " NStore provider tests"
-echo "   framework : ${TFM}"
-echo "   mongodb   : ${NSTORE_MONGODB:-<unset>}"
-echo "   mssql     : ${NSTORE_MSSQL:+<set>}"
-echo "=================================================================="
-
-# Extra args forwarded to `dotnet test` (e.g. --filter "FullyQualifiedName~Polling"),
-# passed in via the NSTORE_TEST_ARGS environment variable. Word-split on spaces.
-read -r -a EXTRA_ARGS <<< "${NSTORE_TEST_ARGS:-}"
-
-failed=()
-for project in "${PROJECTS[@]}"; do
-  name="$(basename "$(dirname "$project")")"
-  echo ""
-  echo ">>> Testing ${name} (${TFM})"
-  if dotnet test "$project" \
-      --framework "$TFM" \
-      --nologo \
-      --logger "console;verbosity=normal" \
-      "${EXTRA_ARGS[@]}"; then
-    echo "<<< ${name}: PASSED"
-  else
-    echo "<<< ${name}: FAILED"
-    failed+=("$name")
-  fi
-done
-
-echo ""
-echo "=================================================================="
-if [ ${#failed[@]} -eq 0 ]; then
-  echo " All provider test suites passed."
+run_all() {
   echo "=================================================================="
-  exit 0
-fi
+  echo " NStore provider tests"
+  echo "   framework : ${TFM}"
+  echo "   mongodb   : ${NSTORE_MONGODB:-<unset>}"
+  echo "   mssql     : ${NSTORE_MSSQL:+<set>}"
+  echo "   results   : ${RESULTS_DIR}"
+  echo "=================================================================="
 
-echo " FAILED suites: ${failed[*]}"
-echo "=================================================================="
-exit 1
+  local failed=()
+  for project in "${PROJECTS[@]}"; do
+    local name
+    name="$(basename "$(dirname "$project")")"
+    echo ""
+    echo ">>> Testing ${name} (${TFM})"
+    if dotnet test "$project" \
+        --framework "$TFM" \
+        --nologo \
+        --logger "console;verbosity=normal" \
+        --logger "trx;LogFileName=${name}.trx" \
+        --results-directory "$RESULTS_DIR" \
+        "${EXTRA_ARGS[@]}"; then
+      echo "<<< ${name}: PASSED"
+    else
+      echo "<<< ${name}: FAILED"
+      failed+=("$name")
+    fi
+  done
+
+  echo ""
+  echo "=================================================================="
+  if [ ${#failed[@]} -eq 0 ]; then
+    echo " All provider test suites passed."
+    echo " Results (console log + .trx per suite): ${RESULTS_DIR}"
+    echo "=================================================================="
+    return 0
+  fi
+
+  echo " FAILED suites: ${failed[*]}"
+  echo " See ${RESULTS_DIR}/run.log and the per-suite .trx files for details."
+  echo "=================================================================="
+  return 1
+}
+
+mkdir -p "$RESULTS_DIR"
+rm -f "$RESULTS_DIR"/*.trx "$RESULTS_DIR"/run.log 2>/dev/null || true
+
+# Tee the whole run to run.log while keeping live console output. Piping (rather than
+# exec redirection) guarantees tee flushes before the script exits.
+run_all | tee "$RESULTS_DIR/run.log"
+exit "${PIPESTATUS[0]}"

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Entry point executed INSIDE the .NET SDK runner container (see docker-compose.tests.yml).
+# Runs each real-provider persistence test suite and reports a combined result.
+# Not meant to be run directly on the host - use ./test-with-docker.sh instead.
+set -uo pipefail
+
+TFM="${NSTORE_TEST_TFM:-net10.0}"
+
+# Provider test projects to run (in-memory is covered by NStore.Core.Tests and is
+# intentionally excluded here - these are the projects that need real providers).
+PROJECTS=(
+  "src/NStore.Persistence.Sqlite.Tests/NStore.Persistence.Sqlite.Tests.csproj"
+  "src/NStore.Persistence.Mongo.Tests/NStore.Persistence.Mongo.Tests.csproj"
+  "src/NStore.Persistence.MsSql.Tests/NStore.Persistence.MsSql.Tests.csproj"
+)
+
+echo "=================================================================="
+echo " NStore provider tests"
+echo "   framework : ${TFM}"
+echo "   mongodb   : ${NSTORE_MONGODB:-<unset>}"
+echo "   mssql     : ${NSTORE_MSSQL:+<set>}"
+echo "=================================================================="
+
+# Extra args forwarded to `dotnet test` (e.g. --filter "FullyQualifiedName~Polling"),
+# passed in via the NSTORE_TEST_ARGS environment variable. Word-split on spaces.
+read -r -a EXTRA_ARGS <<< "${NSTORE_TEST_ARGS:-}"
+
+failed=()
+for project in "${PROJECTS[@]}"; do
+  name="$(basename "$(dirname "$project")")"
+  echo ""
+  echo ">>> Testing ${name} (${TFM})"
+  if dotnet test "$project" \
+      --framework "$TFM" \
+      --nologo \
+      --logger "console;verbosity=normal" \
+      "${EXTRA_ARGS[@]}"; then
+    echo "<<< ${name}: PASSED"
+  else
+    echo "<<< ${name}: FAILED"
+    failed+=("$name")
+  fi
+done
+
+echo ""
+echo "=================================================================="
+if [ ${#failed[@]} -eq 0 ]; then
+  echo " All provider test suites passed."
+  echo "=================================================================="
+  exit 0
+fi
+
+echo " FAILED suites: ${failed[*]}"
+echo "=================================================================="
+exit 1

--- a/docs/reviews/polling-delivery-durability-review.md
+++ b/docs/reviews/polling-delivery-durability-review.md
@@ -1,0 +1,132 @@
+# Polling delivery durability review
+
+Date: 2026-07-13
+
+## Outcome
+
+NStore had a confirmed `PollingClient` defect: the internal position advanced before the
+subscription task completed. Persistence providers report subscription exceptions through
+`OnErrorAsync`. If that callback returned normally, the next poll started after the failed
+chunk and could lose projection work permanently.
+
+The fix commits `PollingClient.Position` only after `OnNextAsync` completes successfully.
+The existing meaning of `Subscription.Stop` is preserved: it acknowledges the current chunk
+and stops before the next one.
+
+The integrating incident that prompted this review had a separate root cause. Its consumer
+marked downstream work as failed, skipped a required payload write, and nevertheless completed
+normally and saved its checkpoint. NStore cannot distinguish that deliberate acknowledgement
+from successful processing. Hole detection cannot recover an acknowledged position.
+
+## Delivery and persistence guarantees
+
+- A successful `AppendAsync` means the NStore persistence operation completed. NStore has no
+  generic post-commit dispatcher and does not include downstream projection success in the
+  append result.
+- Normal completion of `ISubscription.OnNextAsync` acknowledges the current chunk. `true`
+  continues; `false` acknowledges the current chunk and stops.
+- A faulted or cancelled subscription task does not acknowledge the chunk in `PollingClient`.
+  The live poller retains its prior position, and a later poll can redeliver the failed chunk.
+- `PollingClient` keeps its checkpoint in memory. After restart, the application must construct
+  it with the last durably acknowledged position.
+- Delivery is at least once, not exactly once. A consumer can finish a side effect and then fail
+  before acknowledgement, causing duplicate delivery. Consumers must use a stable identity such
+  as `(PartitionId, OperationId)` and make side effects idempotent.
+- Returning success after skipping required work is an acknowledgement. NStore cannot inspect a
+  consumer's private failure flags, downstream writes, or external checkpoint transaction.
+- Cancellation stops the current read. Chunks whose callbacks completed successfully remain
+  acknowledged; later chunks resume from the retained position.
+- Hole detection is an ordering aid, not failure detection. The current compatibility behavior
+  retries a missing global position five times and can then skip a persistently absent position.
+  It cannot recreate or reject a position that a consumer already acknowledged.
+
+## Decisions and rejected alternatives
+
+1. **Commit the position after successful callback completion.** This is the smallest change
+   that restores at-least-once polling after transient consumer exceptions.
+2. **Keep the synchronous completion fast path.** Most subscriptions return the cached
+   `Subscription.Continue` task. That path updates state and returns a cached task without an
+   async state-machine allocation. Genuinely asynchronous callbacks use a small await helper.
+3. **Do not reinterpret `Subscription.Stop` as a negative acknowledgement.** Existing callers
+   use it to process one chunk successfully and stop. Changing it would break checkpoint and
+   resume behavior. Consumers that need retry must fault or cancel the callback.
+4. **Do not add MongoDB-specific retry or telemetry logic.** The defect is above the provider
+   boundary and reproduces with `InMemoryPersistence`. The fix uses only `ISubscription` and is
+   independent of MongoDB server and driver releases.
+5. **Do not add a durable checkpoint store or downstream result type in this fix.** NStore does
+   not own consumer side effects or their transaction. Such an API would expand the abstraction
+   without preventing a consumer from falsely reporting success.
+6. **Do not fold post-commit dispatch into `AppendAsync`.** Persistence durability and downstream
+   delivery are different transactions. Applications that need durable fan-out should poll the
+   persisted log or use a transactional outbox and acknowledge only after required durable work.
+
+## Deterministic evidence
+
+Before the production change, the six focused acknowledgement tests produced two passes and four
+expected failures:
+
+- failure advanced `Position` from `0` to `1`;
+- same-poller retry delivered `1,2,3` instead of `1,1,2,3`;
+- restart from the retained checkpoint delivered only `2` instead of `1,2`;
+- an ambiguous side-effect failure delivered once instead of demonstrating at-least-once
+  duplicate delivery.
+
+After the change, all six tests pass. They cover transient failure, same-poller retry, restart,
+ordering, duplicate delivery and idempotent application, cancellation, and the acknowledgement
+meaning of `Subscription.Stop`. They use no sleeps, external services, unstable driver telemetry,
+or absolute timing.
+
+Final verification:
+
+- `dotnet test NStore.Core.Tests ... --filter *PollingClientAcknowledgementTests*`: 6 passed;
+- full `NStore.Core.Tests` on `net10.0`: 111 passed;
+- SQLite poller, hole, and cancellation contract tests on `net10.0`: 8 passed;
+- multi-target `NStore.Core.Tests` Release build (`net6.0` and `net10.0`): 0 errors and
+  0 warnings;
+- full 18-project Release solution build: 0 errors. The restored dependency graph reports
+  existing package vulnerability and compatibility warnings unrelated to this change.
+
+The machine has no .NET 6 runtime, so `net6.0` was compile-verified but not executed. The first
+full solution build was intentionally attempted with `--no-restore` and failed only because this
+fresh worktree lacked assets files for untouched projects. `dotnet restore` generated them, and
+the same build then passed.
+
+## MongoDB compatibility
+
+The MongoDB provider already awaits `FindAsync`/cursor operations with cancellation and routes
+read or consumer exceptions to `OnErrorAsync`. Current official MongoDB C# driver sources classify
+network and paused-pool failures as retryable read failures. This NStore change does not classify
+driver exceptions, inspect internal telemetry, alter filters, or change cursor usage. It therefore
+remains compatible with current and future server/driver behavior as long as the provider preserves
+the public `ISubscription` contract.
+
+## Hot-path measurement
+
+A task-scoped BenchmarkDotNet 0.15.8 harness compared the old advance-before-callback
+sequence with the new advance-after-callback sequence on .NET 10.0.9, Apple M5 Pro. The
+harness isolates the acknowledgement branch; it is not a persistence or end-to-end benchmark.
+
+| Callback completion | Old mean | New mean | Old allocation | New allocation |
+| --- | ---: | ---: | ---: | ---: |
+| Cached synchronous task | 0.4871 ns | 0.5087 ns | 0 B | 0 B |
+| Forced asynchronous task | 1.121 μs | 1.095 μs | 96 B | 214 B |
+
+The synchronous path, which includes `Subscription.Continue` and `Subscription.Stop`, remains
+allocation-free. Its measured delta was 0.0216 ns (about 4%). Asynchronous timing was within the
+run's variance; the 118-byte increase is the await continuation required to commit the position
+after the callback finishes. The temporary benchmark project and artifacts were kept outside the
+repository in `/private/tmp`.
+
+## Residual risks
+
+- A consumer that catches a transient failure and returns normally will still lose work by
+  contract. NStore has no generic signal that the acknowledgement is false.
+- Side effects and external checkpoint writes are not atomic with NStore reads. Consumers must
+  be idempotent and persist checkpoints only after required durable side effects.
+- `OnErrorAsync` controls policy. If it throws, a manually invoked `Poll` propagates the error and
+  the background polling task stops; the retained position still allows a later restart to retry.
+- The five-attempt hole-skip policy remains unchanged for compatibility and can skip a position
+  that appears only after the retry window. This is distinct from consumer acknowledgement and
+  warrants a separate design review if deployments can expose long-lived temporary holes.
+- The synchronous callback path avoids new allocations, but the asynchronous path necessarily
+  adds one await state machine so acknowledgement can occur after completion.

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,3 +1,10 @@
+## 1.2.0
+
+- **Breaking (delivery semantics):** `PollingClient` now advances its position only **after** `ISubscription.OnNextAsync` completes successfully. A faulted or cancelled `OnNextAsync` no longer advances the checkpoint, so the chunk is retained and redelivered on the next poll (and after a restart from the last acknowledged position). Previously the position was advanced *before* dispatch, which permanently skipped any chunk whose consumer threw.
+- **Behavioral change to be aware of when upgrading:** consumers that previously threw from `OnNextAsync` had that chunk silently skipped and processing continued; they will now see the chunk retried instead. Delivery is **at least once** — make side effects idempotent using a stable chunk identity. A chunk that always fails will be retried indefinitely (there is no dead-letter/max-retry for consumer failures, unlike the existing five-attempt hole-skip policy), so a permanently failing chunk blocks the projection and re-invokes `OnErrorAsync` each poll.
+- `Subscription.Stop` semantics are unchanged: the current chunk is acknowledged, then polling stops before the next chunk.
+- `ISubscription` documentation updated to describe the acknowledgement contract; `OnErrorAsync` now explicitly states the failed chunk is not acknowledged and durable checkpoints must not be advanced from that callback.
+
 ## 1.1.0
 
 - Added synchronous Mongo persistence initialization support with `Init()`, plus safer Mongo cleanup via `DropAsync()` when collection drop permissions are limited.

--- a/src/NStore.Core.Tests/Persistence/PollingClientAcknowledgementTests.cs
+++ b/src/NStore.Core.Tests/Persistence/PollingClientAcknowledgementTests.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NStore.Core.InMemory;
+using NStore.Core.Logging;
+using NStore.Core.Persistence;
+using Xunit;
+
+namespace NStore.Core.Tests.Persistence
+{
+    public class PollingClientAcknowledgementTests
+    {
+        [Fact]
+        public async Task transient_consumer_failure_should_not_advance_position()
+        {
+            using var persistence = await CreatePersistenceAsync(1).ConfigureAwait(false);
+            var processingStarted = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var processing = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var subscription = new LambdaSubscription(_ =>
+            {
+                processingStarted.SetResult(null);
+                return processing.Task;
+            });
+            var poller = CreatePoller(persistence, 0, subscription);
+
+            var polling = poller.Poll();
+            await processingStarted.Task.ConfigureAwait(false);
+
+            Assert.Equal(0, poller.Position);
+
+            processing.SetException(new TransientConsumerException());
+            await polling.ConfigureAwait(false);
+
+            Assert.True(subscription.Failed);
+            Assert.Equal(0, poller.Position);
+        }
+
+        [Fact]
+        public async Task transient_consumer_failure_should_retry_in_order_on_same_poller()
+        {
+            using var persistence = await CreatePersistenceAsync(3).ConfigureAwait(false);
+            var deliveries = new List<long>();
+            var shouldFail = true;
+            var subscription = new LambdaSubscription(chunk =>
+            {
+                deliveries.Add(chunk.Position);
+                if (shouldFail)
+                {
+                    shouldFail = false;
+                    throw new TransientConsumerException();
+                }
+
+                return Subscription.Continue;
+            });
+            var poller = CreatePoller(persistence, 0, subscription);
+
+            await poller.Poll().ConfigureAwait(false);
+            await poller.Poll().ConfigureAwait(false);
+
+            Assert.Equal(new long[] { 1, 1, 2, 3 }, deliveries);
+            Assert.Equal(3, poller.Position);
+        }
+
+        [Fact]
+        public async Task restart_from_last_committed_position_should_retry_failed_chunk()
+        {
+            using var persistence = await CreatePersistenceAsync(2).ConfigureAwait(false);
+            var failingSubscription = new LambdaSubscription(_ => throw new TransientConsumerException());
+            var failedPoller = CreatePoller(persistence, 0, failingSubscription);
+
+            await failedPoller.Poll().ConfigureAwait(false);
+            var lastCommittedPosition = failedPoller.Position;
+
+            var deliveriesAfterRestart = new List<long>();
+            var restartedSubscription = new LambdaSubscription(chunk =>
+            {
+                deliveriesAfterRestart.Add(chunk.Position);
+                return Subscription.Continue;
+            });
+            var restartedPoller = CreatePoller(persistence, lastCommittedPosition, restartedSubscription);
+
+            await restartedPoller.Poll().ConfigureAwait(false);
+
+            Assert.Equal(new long[] { 1, 2 }, deliveriesAfterRestart);
+            Assert.Equal(2, restartedPoller.Position);
+        }
+
+        [Fact]
+        public async Task ambiguous_failure_may_redeliver_with_stable_identity_for_idempotency()
+        {
+            using var persistence = await CreatePersistenceAsync(1).ConfigureAwait(false);
+            var deliveryIdentities = new List<string>();
+            var appliedEffects = new HashSet<string>();
+            var shouldFailAfterSideEffect = true;
+            var subscription = new LambdaSubscription(chunk =>
+            {
+                var identity = $"{chunk.PartitionId}:{chunk.OperationId}";
+                deliveryIdentities.Add(identity);
+                appliedEffects.Add(identity);
+
+                if (shouldFailAfterSideEffect)
+                {
+                    shouldFailAfterSideEffect = false;
+                    throw new TransientConsumerException();
+                }
+
+                return Subscription.Continue;
+            });
+            var poller = CreatePoller(persistence, 0, subscription);
+
+            await poller.Poll().ConfigureAwait(false);
+            await poller.Poll().ConfigureAwait(false);
+
+            Assert.Equal(2, deliveryIdentities.Count);
+            Assert.Single(deliveryIdentities.Distinct());
+            Assert.Single(appliedEffects);
+            Assert.Equal(1, poller.Position);
+        }
+
+        [Fact]
+        public async Task cancellation_should_commit_only_acknowledged_chunks_and_resume()
+        {
+            using var persistence = await CreatePersistenceAsync(3).ConfigureAwait(false);
+            using var cancellation = new CancellationTokenSource();
+            var deliveries = new List<long>();
+            var subscription = new LambdaSubscription(chunk =>
+            {
+                deliveries.Add(chunk.Position);
+                if (chunk.Position == 1)
+                {
+                    cancellation.Cancel();
+                }
+
+                return Subscription.Continue;
+            });
+            var poller = CreatePoller(persistence, 0, subscription);
+
+            await poller.Poll(cancellation.Token).ConfigureAwait(false);
+
+            Assert.Equal(new long[] { 1 }, deliveries);
+            Assert.Equal(1, poller.Position);
+
+            await poller.Poll().ConfigureAwait(false);
+
+            Assert.Equal(new long[] { 1, 2, 3 }, deliveries);
+            Assert.Equal(3, poller.Position);
+        }
+
+        [Fact]
+        public async Task stop_should_acknowledge_current_chunk_and_resume_at_next_chunk()
+        {
+            using var persistence = await CreatePersistenceAsync(3).ConfigureAwait(false);
+            var deliveries = new List<long>();
+            var shouldStop = true;
+            var subscription = new LambdaSubscription(chunk =>
+            {
+                deliveries.Add(chunk.Position);
+                if (shouldStop)
+                {
+                    shouldStop = false;
+                    return Subscription.Stop;
+                }
+
+                return Subscription.Continue;
+            });
+            var poller = CreatePoller(persistence, 0, subscription);
+
+            await poller.Poll().ConfigureAwait(false);
+
+            Assert.Equal(new long[] { 1 }, deliveries);
+            Assert.Equal(1, poller.Position);
+
+            await poller.Poll().ConfigureAwait(false);
+
+            Assert.Equal(new long[] { 1, 2, 3 }, deliveries);
+            Assert.Equal(3, poller.Position);
+        }
+
+        private static PollingClient CreatePoller(
+            InMemoryPersistence persistence,
+            long lastPosition,
+            ISubscription subscription)
+        {
+            return new PollingClient(
+                persistence,
+                lastPosition,
+                subscription,
+                NStoreNullLoggerFactory.Instance);
+        }
+
+        private static async Task<InMemoryPersistence> CreatePersistenceAsync(int eventCount)
+        {
+            var persistence = new InMemoryPersistence();
+            for (var index = 1; index <= eventCount; index++)
+            {
+                await persistence.AppendAsync(
+                        "projection-source",
+                        index,
+                        $"event-{index}",
+                        $"operation-{index}",
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
+            return persistence;
+        }
+
+        private sealed class TransientConsumerException : Exception
+        {
+        }
+    }
+}

--- a/src/NStore.Core/Persistence/ISubscription.cs
+++ b/src/NStore.Core/Persistence/ISubscription.cs
@@ -17,13 +17,22 @@ namespace NStore.Core.Persistence
 
         /// <summary>
         /// <para>
-        /// Handles the next <see cref="IChunk"/> in the persistence layer, and returns true
-        /// if it want the caller to read again next data.
+        /// Handles the next <see cref="IChunk"/> in the persistence layer.
+        /// Normal task completion acknowledges the current chunk. Return
+        /// <see cref="Subscription.Continue"/> to acknowledge it and continue reading, or
+        /// <see cref="Subscription.Stop"/> to acknowledge it and stop before the next chunk.
+        /// Fault or cancel the task when the current chunk was not processed successfully.
+        /// A polling caller can then retain its previous position and redeliver the chunk.
+        /// Consumers must not swallow transient failures or advance durable checkpoints before
+        /// all required side effects have completed.
+        /// </para>
+        /// <para>
+        /// Delivery can be repeated when the processing outcome is ambiguous, so consumers
+        /// should use a stable chunk identity and make side effects idempotent.
         /// </para>
         /// </summary>
         /// <param name="chunk"></param>
-        /// <returns><see cref="Subscription.Stop"/> if this component does not want any more <see cref="IChunk"/> to be
-        /// dispatched, <see cref="Subscription.Continue"/> if it is everything ok and the caller should continue reading next <see cref="IChunk"/></returns>
+        /// <returns>The acknowledgement and continuation decision for the current chunk.</returns>
         Task<bool> OnNextAsync(IChunk chunk);
 
         /// <summary>
@@ -49,7 +58,9 @@ namespace NStore.Core.Persistence
         /// <para>
         /// Called when there is an exception reading or dispatching the next chunk. The real
         /// concrete subscription can then take any action it determines to be done to recover
-        /// from the error.
+        /// from the error. The failed chunk has not been acknowledged by
+        /// <see cref="PollingClient"/> and can be delivered again. Implementations must not
+        /// advance a durable checkpoint for that chunk from this callback.
         /// </para>
         /// </summary>
         /// <param name="indexOrPosition"></param>

--- a/src/NStore.Core/Persistence/PollingClient.cs
+++ b/src/NStore.Core/Persistence/PollingClient.cs
@@ -38,11 +38,49 @@ namespace NStore.Core.Persistence
                     _logger.LogWarning("Skipping hole on {Position}", chunk.Position);
                 }
 
+                // At-least-once delivery: dispatch the chunk to the consumer FIRST and only
+                // advance our position once it completes successfully. If OnNextAsync faults
+                // or is cancelled we deliberately leave Position untouched so the next poll
+                // re-reads (redelivers) this same chunk instead of skipping it.
+                var processing = _subscription.OnNextAsync(chunk);
+                if (processing.Status == TaskStatus.RanToCompletion)
+                {
+                    // Fast path: the consumer completed synchronously (e.g. a cached
+                    // Subscription.Continue/Stop task). Acknowledge inline and reuse the cached
+                    // result task to keep this common path allocation-free.
+                    return Acknowledge(chunk, processing.Result);
+                }
+
+                // The consumer is running asynchronously, or already faulted/cancelled. Await it
+                // so that acknowledgement happens only after a successful completion; a faulted
+                // or cancelled task rethrows here before MarkProcessed runs.
+                return AwaitAndAcknowledge(processing, chunk);
+            }
+
+            private Task<bool> Acknowledge(IChunk chunk, bool shouldContinue)
+            {
+                MarkProcessed(chunk);
+                return shouldContinue ? Subscription.Continue : Subscription.Stop;
+            }
+
+            // Commits the chunk as processed: advances the position (so it will not be
+            // redelivered) and resets hole-detection state. Called only after the consumer has
+            // successfully handled the chunk.
+            private void MarkProcessed(IChunk chunk)
+            {
                 RetriesOnHole = 0;
                 _stopOnHole = true;
                 Position = chunk.Position;
                 Processed++;
-                return _subscription.OnNextAsync(chunk);
+            }
+
+            private async Task<bool> AwaitAndAcknowledge(Task<bool> processing, IChunk chunk)
+            {
+                // If the consumer faults or cancels, the await rethrows and MarkProcessed is
+                // skipped, so Position stays on the previous chunk and delivery is retried.
+                var shouldContinue = await processing.ConfigureAwait(false);
+                MarkProcessed(chunk);
+                return shouldContinue;
             }
 
             public Task OnStartAsync(long indexOrPosition)

--- a/test-with-docker.sh
+++ b/test-with-docker.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run the NStore provider test suites (MongoDB, SQL Server, SQLite) against real
+# providers in Docker. The only prerequisite is Docker with the Compose plugin.
+#
+#   ./test-with-docker.sh
+#   ./test-with-docker.sh --filter "FullyQualifiedName~Polling"   # forwarded to dotnet test
+#
+# Environment overrides:
+#   MSSQL_SA_PASSWORD   SQL Server 'sa' password (default: NStore_Test_Passw0rd!)
+#   NSTORE_TEST_TFM     target framework (default: net10.0)
+set -euo pipefail
+
+cd "$(dirname "$0")"
+COMPOSE_FILE="docker-compose.tests.yml"
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "error: 'docker compose' is required (Docker Desktop or the compose plugin)." >&2
+  exit 1
+fi
+
+# Extra args become the runner's `dotnet test` arguments.
+if [ "$#" -gt 0 ]; then
+  export NSTORE_TEST_ARGS="$*"
+fi
+
+cleanup() {
+  # Stop and remove the containers/network. Named volumes (NuGet cache, SQLite build
+  # output) are kept on purpose to speed up subsequent runs; DB data is ephemeral
+  # (Mongo uses tmpfs, SQL Server lives in the container layer) so nothing leaks.
+  docker compose -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# --exit-code-from tests makes this script exit with the test runner's status
+# and tears down the DB containers as soon as the runner finishes.
+docker compose -f "$COMPOSE_FILE" up \
+  --build \
+  --abort-on-container-exit \
+  --exit-code-from tests

--- a/test-with-docker.sh
+++ b/test-with-docker.sh
@@ -31,9 +31,23 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# --exit-code-from tests makes this script exit with the test runner's status
-# and tears down the DB containers as soon as the runner finishes.
+mkdir -p TestResults
+
+# --exit-code-from tests makes the run exit with the test runner's status and tears
+# down the DB containers as soon as the runner finishes. Capture the status so we can
+# always point at the results, whether the run passed or failed.
+rc=0
 docker compose -f "$COMPOSE_FILE" up \
   --build \
   --abort-on-container-exit \
-  --exit-code-from tests
+  --exit-code-from tests || rc=$?
+
+echo ""
+if [ "$rc" -eq 0 ]; then
+  echo "PASSED. Results in ./TestResults (run.log + one .trx per suite)."
+else
+  echo "FAILED (exit ${rc}). Inspect ./TestResults/run.log or the per-suite .trx files:"
+  echo "  - grep -E 'Failed|error|FAILED suites' TestResults/run.log"
+  ls -1 TestResults/*.trx 2>/dev/null | sed 's/^/  - /' || true
+fi
+exit "$rc"


### PR DESCRIPTION
## Summary

- commit `PollingClient.Position` only after `ISubscription.OnNextAsync` completes successfully
- preserve the existing `Subscription.Stop` contract: acknowledge the current chunk, then stop
- keep cached synchronous callbacks allocation-free with a completed-task fast path
- document at-least-once delivery, durable checkpoint, idempotency, cancellation, and hole-detection boundaries
- add deterministic regression coverage for transient failure, retry/restart ordering, duplicates, cancellation, and stop semantics

## Root cause and ownership

NStore had a confirmed defect in `PollingClient.Sequencer.OnNextAsync`: it advanced `Position` before awaiting the consumer. Persistence providers route consumer exceptions to `OnErrorAsync`; if that callback handled the error normally, the next poll began after the failed chunk and projection work could be skipped permanently.

The integrating Jarvis incident also has a separate integration-layer cause. Its temporarily unavailable OmniSearch indexer was represented as a normal callback completion after failed identities were excluded from payload persistence, and its checkpoint was then saved. NStore cannot distinguish that deliberate acknowledgement from success, and hole detection cannot recover an acknowledged position. This PR does not modify Jarvis or its existing performance PR.

## Contract after this change

- successful `AppendAsync` covers NStore persistence, not downstream post-commit dispatch
- normal subscription completion acknowledges the current chunk
- fault/cancellation retains the poller's previous position for later redelivery
- applications must restart from their last durably acknowledged position
- delivery is at least once; consumers must make side effects idempotent using a stable chunk identity
- returning success after skipping required work remains consumer misuse
- the existing five-attempt hole-skip policy is unchanged

## Validation

- regression baseline on unchanged production: 6 focused tests, 2 passed and 4 failed on the expected checkpoint/retry assertions
- focused acknowledgement tests after the fix: 6 passed
- full `NStore.Core.Tests` on `net10.0`: 111 passed
- SQLite poller/hole/cancellation contract tests on `net10.0`: 8 passed
- multi-target Core test build (`net6.0`, `net10.0`): 0 errors, 0 warnings
- full 18-project Release solution build: 0 errors; existing dependency vulnerability/compatibility warnings remain
- `net6.0` compile-verified but not executed because the local machine does not have the .NET 6 runtime

## Performance

A task-scoped BenchmarkDotNet 0.15.8 comparison on .NET 10.0.9 measured the isolated acknowledgement branch:

| Completion | Before | After | Allocation before | Allocation after |
| --- | ---: | ---: | ---: | ---: |
| Cached synchronous task | 0.4871 ns | 0.5087 ns | 0 B | 0 B |
| Forced asynchronous task | 1.121 μs | 1.095 μs | 96 B | 214 B |

The common cached-task path remains allocation-free. The asynchronous path adds the await continuation required to move acknowledgement after completion.

## MongoDB compatibility

No MongoDB query, cursor, exception classification, telemetry, or driver-specific API changes. The fix is entirely at the public `ISubscription`/poller boundary and was reproduced with `InMemoryPersistence`.

The full decision journal, rejected alternatives, measurements, and residual risks are in `docs/reviews/polling-delivery-durability-review.md`.
